### PR TITLE
Add as-fuzzy command line argument to mark translated messages as fuzzy for future review.

### DIFF
--- a/src/bin/potr/opts.rs
+++ b/src/bin/potr/opts.rs
@@ -69,6 +69,10 @@ pub struct Opts {
     #[clap(long = "include")]
     pub exclude_message: Option<String>,
 
+    /// Mark translated messages as fuzzy.
+    #[clap(long = "fuzzy")]
+    pub as_fuzzy: bool,
+
     /// Print verbose logs.
     #[clap(short, long)]
     pub verbose: bool,
@@ -147,6 +151,7 @@ impl Opts {
                 None => None,
             },
             message_limit: self.limit,
+            as_fuzzy: self.as_fuzzy,
         }
     }
 }

--- a/src/potr.rs
+++ b/src/potr.rs
@@ -25,6 +25,7 @@ pub struct PotrConfig {
     pub include_message_regex: Option<Regex>,
     pub exclude_message_regex: Option<Regex>,
     pub message_limit: i32,
+    pub as_fuzzy: bool,
 }
 
 impl Default for PotrConfig {
@@ -40,6 +41,7 @@ impl Default for PotrConfig {
             include_message_regex: None,
             exclude_message_regex: None,
             message_limit: 0,
+            as_fuzzy: false,
         }
     }
 }
@@ -158,6 +160,10 @@ impl Potr {
         let translated = translator.translate(&message.msgid()).await?;
         tracing::debug!("Translation completed: Result = {}\n", translated);
         message.set_msgstr(translated)?;
+
+        if self.config.as_fuzzy {
+            message.flags_mut().add_flag("fuzzy");
+        }
 
         return Ok(true);
     }

--- a/tests/data/fuzzy-expected.po
+++ b/tests/data/fuzzy-expected.po
@@ -1,0 +1,26 @@
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Translation text\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-06-25 20:04-0700\n"
+"Last-Translator: r12f <r12f.code@gmail.com>\n"
+"Language-Team: English\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/SUMMARY.md:3
+#, fuzzy
+msgid "This is a pen!"
+msgstr "This is a pen!"
+
+#: src/Code.md:3
+msgid ""
+"```bash\n"
+"# This is a code block\n"
+"```"
+msgstr ""
+

--- a/tests/data/fuzzy-input.po
+++ b/tests/data/fuzzy-input.po
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Translation text\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-06-25 20:04-0700\n"
+"Last-Translator: r12f <r12f.code@gmail.com>\n"
+"Language-Team: English\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/SUMMARY.md:3
+msgid "This is a pen!"
+msgstr ""
+
+#: src/Code.md:3
+msgid ""
+"```bash\n"
+"# This is a code block\n"
+"```"
+msgstr ""

--- a/tests/potr_tests.rs
+++ b/tests/potr_tests.rs
@@ -58,6 +58,14 @@ async fn potr_should_translate_code_block_messages_with_include_regex() {
     run_potr_test("code-block-with-include-regex", potr_config).await;
 }
 
+#[tokio::test]
+async fn potr_should_mark_translated_message_as_fuzzy() {
+    let mut potr_config = PotrConfig::default();
+    potr_config.as_fuzzy = true;
+
+    run_potr_test("fuzzy", potr_config).await;
+}
+
 async fn run_potr_test(test_name: &str, mut potr_config: PotrConfig) {
     potr_config.po_file_path = format!("tests/data/{}-input.po", test_name);
     potr_config.output_file_path = format!("tests/data/{}-result.po", test_name);


### PR DESCRIPTION
Before the change:

```
#: src/SUMMARY.md:3
msgid "This is a pen!"
msgstr "This is a pen!"
```


After enabling `--fuzzy`:

```
#: src/SUMMARY.md:3
#, fuzzy
msgid "This is a pen!"
msgstr "This is a pen!"
```